### PR TITLE
PRO-5641: favicon editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
-## 1.0.0
+## UNRELEASED
+
+Initial release.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,7 @@
-Copyright (c) 2022, 2023 Apostrophe Technologies
+Copyright (c) 2024 Apostrophe Technologies, Inc.
 
-Please contact hello@apostrophecms.com for terms of use.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ As such, it pairs well with the Apostrophe palette and multisite modulees.
 To install the module, use the command line to run this command in an Apostrophe project's root directory:
 
 ```
-npm install @apostrophecms-pro/favicon
+npm install @apostrophecms/favicon
 ```
 
 ## Usage
 
-Configure the `@apostrophecms-pro/favicon` module in the `app.js` file:
+Configure the `@apostrophecms/favicon` module in the `app.js` file:
 
 ```javascript
 require('apostrophe')({
   shortName: 'my-project',
   modules: {
-    '@apostrophecms-pro/favicon': {}
+    '@apostrophecms/favicon': {}
   }
 });
 ```
@@ -43,3 +43,6 @@ cropped if you do not use the cropping interface manually.
 
 There are no special requirements for images uploaded for this purpose, however you may
 wish to use a PNG file in order to achieve transparency effects.
+
+> Browsers vary in terms of how quickly you will see the new favicon image, but a
+> page refresh usually suffices.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="https://raw.githubusercontent.com/apostrophecms/apostrophe/main/logo.svg" alt="ApostropheCMS logo" width="80" height="80">
 
-  <h1>Apostrophe PRO Module Template</h1>
+  <h1>Editable Favicons for ApostropheCMS</h1>
   <p>
     <a aria-label="Apostrophe logo" href="https://v3.docs.apostrophecms.org">
       <img src="https://img.shields.io/badge/MADE%20FOR%20Apostrophe%203-000000.svg?style=for-the-badge&logo=Apostrophe&labelColor=6516dd">
@@ -12,37 +12,34 @@
   </p>
 </div>
 
-This module template serves as a starting point for new official Apostrophe PRO modules. This is where you would describe what the purpose of the module is.
+This module allows users to edit the "favicon" (browser tab icon) of the site via the global settings of the site.
+As such, it pairs well with the Apostrophe palette and multisite modulees.
 
 ## Installation
 
 To install the module, use the command line to run this command in an Apostrophe project's root directory:
 
 ```
-npm install @apostrophecms/pro-module-template
+npm install @apostrophecms-pro/favicon
 ```
 
 ## Usage
 
-Configure the _______ module in the `app.js` file:
+Configure the `@apostrophecms-pro/favicon` module in the `app.js` file:
 
 ```javascript
 require('apostrophe')({
   shortName: 'my-project',
   modules: {
-    '@apostrophecms/pro-module-template': {}
+    '@apostrophecms-pro/favicon': {}
   }
 });
 ```
 
-### Additional usage sections
+You do not have to do anything else. You can access the global settings of the site
+via the "Gear" button in the upper right. Once there, select the "Favicon" tab and
+choose your preferred image. Note that a square portion of the image is automatically
+cropped if you do not use the cropping interface manually.
 
-### Pre-release checks
-
-- [ ] If the module does not include CSS, remove the Stylelint config file and dependency `npm remove --save-dev stylelint stylelint-config-apostrophe`
-- [ ] If the module does not include any Vue.js components, remove 
-  - [ ] set in `package.json`, `"eslint": "eslint .",`
-  - [ ] remove Vue.js packages `npm remove --save-dev eslint-plugin-vue vue-eslint-parser`
-- [ ] If the module does not contains any tests, remove mocha `npm remove --save-dev mocha`
-- [ ] If this file contains images, please use public static endpoint to load the images.
-- [ ] If any template includes a script with inline code, include the `nonce` attribute set like this: `<script nonce="{{ nonce }}">`.
+There are no special requirements for images uploaded for this purpose, however you may
+wish to use a PNG file in order to achieve transparency effects.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="https://raw.githubusercontent.com/apostrophecms/apostrophe/main/logo.svg" alt="ApostropheCMS logo" width="80" height="80">
 
-  <h1>Editable Favicons for ApostropheCMS</h1>
+  <h1>Favicons for ApostropheCMS</h1>
   <p>
     <a aria-label="Apostrophe logo" href="https://v3.docs.apostrophecms.org">
       <img src="https://img.shields.io/badge/MADE%20FOR%20Apostrophe%203-000000.svg?style=for-the-badge&logo=Apostrophe&labelColor=6516dd">

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = {
       head(req) {
         const doc = req.data.global;
         const attachment = self.apos.image.first(doc.favicon);
-        console.log(attachment);
         if (!attachment) {
           return {};
         }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     modules: getBundleModuleNames()
   },
   init(self) {
-    self.apos.template.append('head', '@apostrophecms-pro/favicon:head');
+    self.apos.template.append('head', '@apostrophecms/favicon:head');
   },
   components(self) {
     return {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = {
           url
         };
       }
-    }
+    };
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,26 @@ module.exports = {
   bundle: {
     directory: 'modules',
     modules: getBundleModuleNames()
+  },
+  init(self) {
+    self.apos.template.append('head', '@apostrophecms-pro/favicon:head');
+  },
+  components(self) {
+    return {
+      head(req) {
+        const doc = req.data.global;
+        const attachment = self.apos.image.first(doc.favicon);
+        console.log(attachment);
+        if (!attachment) {
+          return {};
+        }
+        const url = self.apos.attachment.url(attachment, { size: 'one-third' });
+        console.log(url);
+        return {
+          url
+        };
+      }
+    }
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = {
           return {};
         }
         const url = self.apos.attachment.url(attachment, { size: 'one-third' });
-        console.log(url);
         return {
           url
         };

--- a/modules/@apostrophecms/favicon-global/index.js
+++ b/modules/@apostrophecms/favicon-global/index.js
@@ -12,7 +12,7 @@ module.exports = {
             '@apostrophecms/image': {
               minSize: [ 192, 192 ],
               aspectRatio: [ 1, 1 ]
-            },
+            }
           },
           max: 1
         }

--- a/modules/@apostrophecms/favicon-global/index.js
+++ b/modules/@apostrophecms/favicon-global/index.js
@@ -1,5 +1,3 @@
-const util = require('util');
-
 module.exports = {
   improve: '@apostrophecms/global',
   fields: {

--- a/modules/@apostrophecms/favicon-global/index.js
+++ b/modules/@apostrophecms/favicon-global/index.js
@@ -1,0 +1,28 @@
+const util = require('util');
+
+module.exports = {
+  improve: '@apostrophecms/global',
+  fields: {
+    add: {
+      favicon: {
+        label: 'Favicon (browser tab icon)',
+        type: 'area',
+        options: {
+          widgets: {
+            '@apostrophecms/image': {
+              minSize: [ 192, 192 ],
+              aspectRatio: [ 1, 1 ]
+            },
+          },
+          max: 1
+        }
+      }
+    },
+    group: {
+      favicon: {
+        label: 'Favicon',
+        fields: [ 'favicon' ]
+      }
+    }
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@apostrophecms/pro-module-template",
+  "name": "@apostrophecms/favicon",
   "version": "1.0.0",
-  "description": "A template for creating an ApostropheCMS 3 PRO module.",
+  "description": "Edit the favicon (the icon in the browser tab) within ApostropheCMS",
   "main": "index.js",
   "scripts": {
     "eslint": "eslint --ext .js,.vue .",
@@ -10,11 +10,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apostrophecms/pro-module-template.git"
+    "url": "git+https://github.com/apostrophecms/favicon.git"
   },
-  "homepage": "https://github.com/apostrophecms/pro-module-template#readme",
+  "homepage": "https://github.com/apostrophecms/favicon#readme",
   "author": "Apostrophe Technologies",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "devDependencies": {
     "apostrophe": "github:apostrophecms/apostrophe",
     "eslint": "^8.44.0",

--- a/views/head.html
+++ b/views/head.html
@@ -1,0 +1,6 @@
+{% if data.url %}
+  {# desktop & android #}
+  <link rel="icon" href="{{ data.url }}" />
+  {# apple devices #}
+  <link rel="apple-touch-icon" href="{{ data.url }}" />
+{% endif %}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

A simple favicon support module for A3. Takes advantage of the fact that modern devices are much less concerned with the dimensions of the image than they used to be. Apostrophe's `one-third` size (380x380) is served. Lighthouse had no complaints and it looked reasonable both in Chrome and when added to the iPhone homescreen.

Because no custom sizes have to be generated, we should experience none of the complexity and localization/publication gotchas and bugs of the 2.x version.

If it turns out that there is some valid use case for generating custom sizes we can revisit that at a future date.

## What are the specific steps to test this change?

Follow the README to set up and test the module. You don't have to use a multisite project, although that is probably where it will be most used.

## What kind of change does this PR introduce?

*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
